### PR TITLE
fix: Update code analysis settings and enhance CLI handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -47,8 +47,10 @@ dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
 # Apply our rule to constants.
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
-# Disable CA1014
+# Disable rules
 dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.CA1031.severity = none
+dotnet_diagnostic.CA1303.severity = none
 
 [*.{received,verified}.*]
 generated_code = true

--- a/Devantler.CLIRunner.Tests/Devantler.CLIRunner.Tests.csproj
+++ b/Devantler.CLIRunner.Tests/Devantler.CLIRunner.Tests.csproj
@@ -8,7 +8,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Devantler.CLIRunner/CLI.cs
+++ b/Devantler.CLIRunner/CLI.cs
@@ -26,14 +26,18 @@ public static class CLI
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
+    ArgumentNullException.ThrowIfNull(command, nameof(command));
     bool isFaulty = false;
     ConcurrentQueue<string> messageQueue = new();
     try
     {
+      using var standardInput = Console.OpenStandardInput();
+      using var standardOutput = Console.OpenStandardOutput();
+      using var standardError = Console.OpenStandardError();
       var commandEvents = command.WithValidation(validation)
-        .WithStandardInputPipe(PipeSource.FromStream(Console.OpenStandardInput()))
-        .WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
-        .WithStandardErrorPipe(PipeTarget.ToStream(Console.OpenStandardError()))
+        .WithStandardInputPipe(PipeSource.FromStream(standardInput))
+        .WithStandardOutputPipe(PipeTarget.ToStream(standardOutput))
+        .WithStandardErrorPipe(PipeTarget.ToStream(standardError))
         .ListenAsync(cancellationToken: cancellationToken);
       await foreach (var cmdEvent in commandEvents.ConfigureAwait(false))
       {

--- a/Devantler.CLIRunner/Devantler.CLIRunner.csproj
+++ b/Devantler.CLIRunner/Devantler.CLIRunner.csproj
@@ -8,7 +8,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Improve code analysis settings by enabling warnings as errors and disabling specific rules. Enhance CLI input/output handling for better performance and error management.